### PR TITLE
PDDA-474 Adjusting the way cdu lists are populated: removing unneeded…

### DIFF
--- a/src/main/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/CdusController.java
+++ b/src/main/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/CdusController.java
@@ -111,6 +111,9 @@ public class CdusController extends CduRegistrationController {
 
         // Ensure the search command is the latest
         setCduSearchCommand(cduSearchCommand);
+        
+        // Refresh the list of CDU's
+        cduPageStateHolder.setCdus(getCduList(cduSearchCommand));
 
         // Business Specific validation for cdu search
         cduSearchSelectedValidator.validate(cduSearchCommand, result);

--- a/src/main/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/CdusControllerUtility.java
+++ b/src/main/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/CdusControllerUtility.java
@@ -211,7 +211,6 @@ public class CdusControllerUtility {
         if (macAddress != null) {
             // Call to CduService to fetch Cdu's by Mac address
             final List<CduDto> cduList = cduService.getCduByMacAddressWithLike(macAddress);
-            cduPageStateHolder.setCdus(cduList);
             for (CduDto cdu : cduList) {
                 if (cdu.getMacAddress().equals(macAddress)) {
                     selectedCdu = cdu;
@@ -297,11 +296,6 @@ public class CdusControllerUtility {
         
         // Ensure the search command is the latest
         cduPageStateHolder.setCduSearchCommand(cduSearchCommand);
-        
-        // Populate the cdus for this site
-        final List<CduDto> cduList = 
-            cduService.getCdusBySiteID(cduSearchCommand.getXhibitCourtSiteId());
-        cduPageStateHolder.setCdus(cduList);
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/CduRedirectToUrlPage.java
+++ b/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/CduRedirectToUrlPage.java
@@ -48,8 +48,6 @@ abstract class CduRedirectToUrlPage extends CduUrlMappingTest {
         mockCduPageStateHolder.setCdu(cdu);
         expectLastCall();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         mockCduPageStateHolder.setAvailableUrls(urls);
         expectLastCall();
         expect(mockCduPageStateHolder.getAvailableUrls()).andReturn(urls);
@@ -128,8 +126,6 @@ abstract class CduRedirectToUrlPage extends CduUrlMappingTest {
         mockCduPageStateHolder.setCdu(cdu);
         expectLastCall();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         DataRetrievalFailureException dataRetrievalFailureException =
             new DataRetrievalFailureException(MOCK_DATA_EXCEPTION);
         expect(mockUrlService.getUrlsByXhibitCourtSiteId(cdu.getXhibitCourtSiteId()))
@@ -176,8 +172,6 @@ abstract class CduRedirectToUrlPage extends CduUrlMappingTest {
         mockCduPageStateHolder.setCdu(cdu);
         expectLastCall();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         XpdmException xpdmException = new XpdmException(MOCK_RUNTIME_EXCEPTION);
         expect(mockUrlService.getUrlsByXhibitCourtSiteId(cdu.getXhibitCourtSiteId()))
             .andThrow(xpdmException);
@@ -223,8 +217,6 @@ abstract class CduRedirectToUrlPage extends CduUrlMappingTest {
         mockCduPageStateHolder.setCdu(cdu);
         expectLastCall();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         expectCduSearchSelectedValidator(capturedCommand, capturedErrors, true);
 
         replay(mockCduPageStateHolder);

--- a/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/CduShowAmendTest.java
+++ b/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/CduShowAmendTest.java
@@ -45,7 +45,6 @@ class CduShowAmendTest extends UpdateCduTest {
         expectLastCall().times(2);
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class)))
             .andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
         mockCduPageStateHolder.setCdu(cdu);
         expectLastCall();
         expectCduSearchSelectedValidator(capturedCommand, capturedErrors, true);
@@ -121,11 +120,9 @@ class CduShowAmendTest extends UpdateCduTest {
         expectLastCall().anyTimes();
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
         expectLastCall();
-        
-        expect(mockCduService.getCdusBySiteID(EasyMock.isA(Long.class))).andReturn(cdus);
+        expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
         mockCduPageStateHolder.setCdus(cdus);
         expectLastCall();
-        
         expectSetModelCduList();
         expectCduSearchSelectedValidator(capturedCommand, capturedErrors, false);
 

--- a/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/RestartCduTest.java
+++ b/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/RestartCduTest.java
@@ -56,8 +56,6 @@ abstract class RestartCduTest extends CduRedirectToUrlPage {
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
         expectLastCall();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         expectSetModelCduList();
         expectCduSearchSelectedValidator(capturedCommand, capturedErrors, true);
         mockCduService.restartCdu(selectedCdus);
@@ -144,8 +142,6 @@ abstract class RestartCduTest extends CduRedirectToUrlPage {
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
         expectLastCall();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         expectSetModelCduList();
         expectCduSearchSelectedValidator(capturedCommand, capturedErrors, true);
         mockCduService.restartCdu(selectedCdus);
@@ -194,8 +190,6 @@ abstract class RestartCduTest extends CduRedirectToUrlPage {
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
         expectLastCall();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         expectSetModelCduList();
         expectCduSearchSelectedValidator(capturedCommand, capturedErrors, true);
         mockCduService.restartCdu(selectedCdus);

--- a/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/ShowCduTest.java
+++ b/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/ShowCduTest.java
@@ -211,10 +211,7 @@ abstract class ShowCduTest extends TestCdus {
         mockCduPageStateHolder.setSites(sites);
         expectLastCall();
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
-        
-        expect(mockCduService.getCdusBySiteID(EasyMock.isA(Long.class))).andReturn(cdus);
         mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall().times(2);
         mockCduPageStateHolder.setCdus(null);
         expectLastCall();
         expectSetModelCduList();
@@ -258,9 +255,6 @@ abstract class ShowCduTest extends TestCdus {
 
         // Add the mock calls to child classes
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
-        expectLastCall();
-        expect(mockCduService.getCdusBySiteID(EasyMock.isA(Long.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
         expectLastCall();
         mockCduPageStateHolder.setSites(sites);
         expectLastCall();
@@ -308,9 +302,6 @@ abstract class ShowCduTest extends TestCdus {
 
         // Add the mock calls to child classes
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
-        expectLastCall();
-        expect(mockCduService.getCdusBySiteID(EasyMock.isA(Long.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
         expectLastCall();
         mockCduPageStateHolder.setSites(sites);
         expectLastCall();
@@ -361,11 +352,9 @@ abstract class ShowCduTest extends TestCdus {
         expectLastCall();
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
         expectLastCall();
-        expect(mockCduService.getCdusBySiteID(EasyMock.isA(Long.class))).andReturn(cdus);
         mockCduPageStateHolder.setCdus(null);
         expectLastCall();
         mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall().times(2);
         expectSetModelCduList();
         
         expectCduSearchValidator(capturedCommand, capturedErrors, true);
@@ -411,9 +400,7 @@ abstract class ShowCduTest extends TestCdus {
         expectLastCall();
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
         expectLastCall();
-        expect(mockCduService.getCdusBySiteID(EasyMock.isA(Long.class))).andReturn(null);
         mockCduPageStateHolder.setCdus(null);
-        expectLastCall().times(2);
         expectSetModelCduList();
         expectCduSearchValidator(capturedCommand, capturedErrors, false);
         
@@ -456,7 +443,7 @@ abstract class ShowCduTest extends TestCdus {
         expectLastCall();
         expect(mockCduService.getCdusBySiteID(EasyMock.isA(Long.class))).andReturn(cdus);
         mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall().times(2);
+        expectLastCall();
         mockCduPageStateHolder.setCdu(cdu);
         expectLastCall();
         expectSetModelCduList();

--- a/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/ShowRegisterCduTest.java
+++ b/src/test/java/uk/gov/hmcts/pdm/publicdisplay/manager/web/cdus/ShowRegisterCduTest.java
@@ -61,8 +61,6 @@ abstract class ShowRegisterCduTest extends ShowCduTest {
         mockCduPageStateHolder.setCduSearchCommand(capture(capturedCommand));
         expectLastCall();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         mockCduPageStateHolder.setCdu(cdu);
         expectLastCall();
         expect(mockLocalProxyService.getCourtSiteByXhibitCourtSiteId(cdu.getXhibitCourtSiteId()))
@@ -323,7 +321,6 @@ abstract class ShowRegisterCduTest extends ShowCduTest {
         expectSetModelCduList();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
         mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall().times(2);
         expectUnregisterCduValidator(capturedCommand, capturedErrors, true);
         mockCduService.unregisterCdu(cdu.getId());
         expectLastCall();
@@ -408,8 +405,6 @@ abstract class ShowRegisterCduTest extends ShowCduTest {
         expectLastCall();
         expectSetModelCduList();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         mockCduUnregisterValidator.validate(capture(capturedCommand), capture(capturedErrors));
         expectLastCall();
         mockCduService.unregisterCdu(cdu.getId());
@@ -456,8 +451,6 @@ abstract class ShowRegisterCduTest extends ShowCduTest {
         expectLastCall();
         expectSetModelCduList();
         expect(mockCduService.getCduByMacAddressWithLike(EasyMock.isA(String.class))).andReturn(cdus);
-        mockCduPageStateHolder.setCdus(cdus);
-        expectLastCall();
         mockCduUnregisterValidator.validate(capture(capturedCommand), capture(capturedErrors));
         expectLastCall();
         mockCduService.unregisterCdu(cdu.getId());


### PR DESCRIPTION
… call to setCdus() when they are overwritten on the next line and removing another call to setCdus() where it was setting only a specific one and not all cdus for that site. This has been amended with adding a new line for setCdus()

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
